### PR TITLE
fix: show stopped VMs/CTs when Stopped filter is checked

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
@@ -492,7 +492,12 @@ internal partial class MainWindow
                                             || a.Tags.Any(t => _filterTags.Contains(t)));
         }
 
-        var list = filtered.Where(a => a.HasAnyVdiAction).ToList();
+        // When the user explicitly ticks the Stopped status filter, include powerable rows
+        // even if they have no live VDI action — otherwise the Start button can't be reached
+        // for stopped VMs/CTs.
+        var showStopped = _chkStopped.IsChecked is true;
+        var list = filtered.Where(a => a.HasAnyVdiAction
+                                       || (showStopped && a.CanPower && !a.IsActive)).ToList();
         RebuildCardView(list);
         RebuildListView(list);
     }


### PR DESCRIPTION
Closes #24

## Summary

The sidebar **Stopped** checkbox had no effect: stopped VMs/CTs were always filtered out, so users with the **Show Start button** preference enabled had no row to click and couldn't start VMs from cv4pve-vdi at all.

## Root cause

`MainWindow.Common.ApplyFilter()` ends with an extra `HasAnyVdiAction` guard:

```csharp
var list = filtered.Where(a => a.HasAnyVdiAction).ToList();
```

`HasAnyVdiAction` requires SPICE, VNC or a configured service — none of which a stopped VM has. So the row was dropped before reaching the view, regardless of the Stopped checkbox.

## Fix

When the user explicitly ticks **Stopped**, also include rows that are powerable but not active:

```csharp
var showStopped = _chkStopped.IsChecked is true;
var list = filtered.Where(a => a.HasAnyVdiAction
                               || (showStopped && a.CanPower && !a.IsActive)).ToList();
```

Behaviour matrix:

| Stopped checkbox | Before | After |
|---|---|---|
| OFF (default) | Only VMs with SPICE/VNC/services shown | Same |
| ON | Same as OFF (bug) | Stopped powerable VMs shown too |

No new settings added — the existing Stopped filter now does what its label suggests.

## Test plan
- [ ] With **Stopped** off → list shows only active/connectable VMs (unchanged)
- [ ] With **Stopped** on → stopped VMs/CTs with `VM.PowerMgmt` permission appear
- [ ] With **Show Start button** enabled in Settings → the Start button is now reachable on stopped rows