### PR TITLE
feat: include tags in the search filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Download the latest release from the [releases page](https://github.com/Corsinve
 - **VM/CT power control** — Start and Shutdown buttons (with optional confirmation)
 - **Real-time stats** — CPU and RAM usage bars per VM
 - **Auto-refresh** every 30 seconds — toggle from the toolbar
+- **Search bar** — quick filter by name, ID, description or tag
 - **Filter sidebar** — filter by node, pool, status, type and tags
 - **Tag support** — color-coded badges with Proxmox VE tag colors
 - **Multi-host** — manage multiple Proxmox VE clusters from a single client

--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
@@ -454,7 +454,8 @@ internal partial class MainWindow
             var ft = _filterText.Trim().ToLowerInvariant();
             filtered = filtered.Where(a => a.Name.Contains(ft, StringComparison.OrdinalIgnoreCase)
                                             || a.IdDisplay.Contains(ft, StringComparison.OrdinalIgnoreCase)
-                                            || a.Description.Contains(ft, StringComparison.OrdinalIgnoreCase));
+                                            || a.Description.Contains(ft, StringComparison.OrdinalIgnoreCase)
+                                            || a.Tags.Any(t => t.Contains(ft, StringComparison.OrdinalIgnoreCase)));
         }
 
         var filterByStatus = _chkRunning.IsChecked is true || _chkStopped.IsChecked is true;

--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/Resources/Strings.resx
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/Resources/Strings.resx
@@ -40,7 +40,7 @@
   <data name="Settings"><value>Settings</value></data>
 
   <!-- Filter sidebar -->
-  <data name="SearchWatermark"><value>Name, ID, description...</value></data>
+  <data name="SearchWatermark"><value>Name, ID, description, tag...</value></data>
   <data name="ResetFilters"><value>Reset filters</value></data>
   <data name="SectionFilters"><value>FILTERS</value></data>
   <data name="SectionSearch"><value>SEARCH</value></data>


### PR DESCRIPTION
## Summary

Extends the toolbar search bar to also match on **tags**, alongside the existing name / ID / description fields.

## Why

Tags are first-class attributes on VMs in Proxmox and one of the most natural identifiers users think with (`prod`, `dev`, `web`, ...). Today the only way to filter by tag is via the sidebar checkboxes — useful for explicit selection but slower than typing.

The dedicated tag filter in the sidebar stays unchanged — this just makes the search bar do what users naturally expect.

## Changes

- `MainWindow.Common.ApplyFilter()` adds a partial match against `Tags`
- `SearchWatermark` placeholder updated: `Name, ID, description, tag...`
- README mentions the search bar in the Core Capabilities

## Test plan
- [ ] Type a tag substring → matching VMs/CTs appear
- [ ] Other search fields (name / ID / description) still work
- [ ] Sidebar tag filter still works independently