### PR TITLE
feat: empty-state message when no VMs match the current filters

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
@@ -501,5 +501,7 @@ internal partial class MainWindow
                                        || (showStopped && a.CanPower && !a.IsActive)).ToList();
         RebuildCardView(list);
         RebuildListView(list);
+
+        _emptyState.IsVisible = list.Count == 0;
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.cs
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.cs
@@ -100,6 +100,15 @@ internal partial class MainWindow(PveClient client, ClusterConfig host, AppConfi
 
     private readonly StackPanel _cardContent = new() { Spacing = 24 };
     private readonly StackPanel _listContent = new() { Spacing = 16, IsVisible = false };
+    private readonly TextBlock _emptyState = new()
+    {
+        Text = L("NoResults"),
+        FontSize = 14,
+        Opacity = 0.55,
+        HorizontalAlignment = HorizontalAlignment.Center,
+        Margin = new Thickness(0, 48, 0, 0),
+        IsVisible = false
+    };
 
     private ScrollViewer? _sidebar;
 
@@ -319,7 +328,7 @@ internal partial class MainWindow(PveClient client, ClusterConfig host, AppConfi
             {
                 Margin = new Thickness(18, 14),
                 Spacing = 0,
-                Children = { _cardContent, _listContent }
+                Children = { _cardContent, _listContent, _emptyState }
             },
             HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
             VerticalScrollBarVisibility = ScrollBarVisibility.Auto

--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/Resources/Strings.resx
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/Resources/Strings.resx
@@ -41,6 +41,7 @@
 
   <!-- Filter sidebar -->
   <data name="SearchWatermark"><value>Name, ID, description, tag...</value></data>
+  <data name="NoResults"><value>No VMs or containers match the current filters.</value></data>
   <data name="ResetFilters"><value>Reset filters</value></data>
   <data name="SectionFilters"><value>FILTERS</value></data>
   <data name="SectionSearch"><value>SEARCH</value></data>


### PR DESCRIPTION
## Summary

When the active filters (search bar, status checkboxes, sidebar checkboxes...) yield zero results, show a centered low-emphasis message in the main scroll area instead of leaving it blank.

## Before / after

| Before | After |
|---|---|
| Empty white area — looks like a loading bug | "No VMs or containers match the current filters." |

## Changes

- New `_emptyState` TextBlock added next to `_cardContent`/`_listContent` in the scroll container
- `ApplyFilter()` toggles its visibility based on `list.Count == 0`
- New string `NoResults` in `Strings.resx`

## Test plan
- [ ] Type a non-matching search string → empty-state appears
- [ ] Uncheck both Running and Stopped → empty-state appears
- [ ] Apply a tag filter that doesn't match → empty-state appears
- [ ] Reset filters → empty-state hides, list shows again