### PR TITLE
feat: keyboard shortcuts (Ctrl+F, F5, Ctrl+,)

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.cs
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.cs
@@ -112,7 +112,11 @@ internal partial class MainWindow(PveClient client, ClusterConfig host, AppConfi
 
     private ScrollViewer? _sidebar;
 
-    private readonly TextBox _txtSearch = new() { PlaceholderText = L("SearchWatermark") };
+    private readonly TextBox _txtSearch = new()
+    {
+        PlaceholderText = L("SearchWatermark"),
+        [ToolTip.TipProperty] = $"{L("SearchTooltip")} (Ctrl+F)"
+    };
     private readonly StackPanel _nodeFilters = new() { Spacing = 4 };
     private readonly StackPanel _poolFilters = new() { Spacing = 4 };
     private readonly StackPanel _tagFilters = new() { Spacing = 4 };
@@ -211,10 +215,14 @@ internal partial class MainWindow(PveClient client, ClusterConfig host, AppConfi
         var btnAutoRef = _btnAutoRef;
         btnAutoRef.IsCheckedChanged += (_, _) => autoRefLabel.IsVisible = btnAutoRef.IsChecked is true;
 
-        var menuItemSettings = new MenuItem { Header = UiHelper.WithText(AppIcons.Settings, L("Settings")) };
+        var menuItemSettings = new MenuItem
+        {
+            Header = UiHelper.WithText(AppIcons.Settings, L("Settings")),
+            InputGesture = new KeyGesture(Key.OemComma, KeyModifiers.Control)
+        };
         var btnMore = BuildHelpMenu(menuItemSettings);
 
-        ToolTip.SetTip(btnRefresh, L("Refresh"));
+        ToolTip.SetTip(btnRefresh, $"{L("Refresh")} (F5)");
         ToolTip.SetTip(btnAutoRef, L("AutoRefresh"));
 
         var statsPanel = new StackPanel
@@ -390,6 +398,27 @@ internal partial class MainWindow(PveClient client, ClusterConfig host, AppConfi
             MinHeight = 500,
             WindowStartupLocation = WindowStartupLocation.CenterScreen,
             Content = mainGrid
+        };
+
+        // Keyboard shortcuts. Avalonia maps KeyModifiers.Control to Cmd on macOS,
+        // so the same gesture works on Windows / Linux / macOS.
+        _window.KeyDown += async (_, e) =>
+        {
+            if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.F)
+            {
+                _txtSearch.Focus();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.F5)
+            {
+                await RefreshAsync();
+                e.Handled = true;
+            }
+            else if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.OemComma)
+            {
+                menuItemSettings.RaiseEvent(new Avalonia.Interactivity.RoutedEventArgs(MenuItem.ClickEvent));
+                e.Handled = true;
+            }
         };
 
         if (_config.Kiosk)

--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/Resources/Strings.resx
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/Resources/Strings.resx
@@ -41,6 +41,7 @@
 
   <!-- Filter sidebar -->
   <data name="SearchWatermark"><value>Name, ID, description, tag...</value></data>
+  <data name="SearchTooltip"><value>Filter VMs and containers</value></data>
   <data name="NoResults"><value>No VMs or containers match the current filters.</value></data>
   <data name="ResetFilters"><value>Reset filters</value></data>
   <data name="SectionFilters"><value>FILTERS</value></data>


### PR DESCRIPTION
## Summary

Add three standard keyboard shortcuts to the main window, and surface them in tooltips / menu items so they're discoverable.

| Shortcut | Action |
|---|---|
| **Ctrl+F** (Cmd+F on macOS) | Focus the search box |
| **F5** | Manual refresh |
| **Ctrl+,** (Cmd+,) | Open Settings |

## Why

Standard shortcuts for desktop tools (browsers, IDEs, file explorers, Office). Avoid the mouse trip when the user wants to search, refresh or tweak settings.

## Cross-platform note

Avalonia maps `KeyModifiers.Control` to the native modifier on each OS — so the same gesture is **Ctrl** on Windows/Linux and **Cmd** on macOS, matching user expectations everywhere.

## Discoverability

- **Refresh button** tooltip: `Refresh (F5)`
- **Search box** tooltip: `Filter VMs and containers (Ctrl+F)`
- **Settings** menu item: `Ctrl+,` right-aligned (via Avalonia's `InputGesture`, same look as VS Code menus)

## Test plan
- [ ] Ctrl+F focuses the search box from anywhere in the main window
- [ ] F5 triggers a manual refresh
- [ ] Ctrl+, opens the Settings dialog
- [ ] On macOS, the same gestures activate with Cmd
- [ ] Hover Refresh / Search / Settings → tooltip / gesture visible