### PR TITLE
fix: keep stopped powerable VMs visible regardless of VGA type (#37)

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Vdi/UI/MainWindow.Common.cs
@@ -519,12 +519,16 @@ internal partial class MainWindow
                                             || a.Tags.Any(t => _filterTags.Contains(t)));
         }
 
-        // When the user explicitly ticks the Stopped status filter, include powerable rows
-        // even if they have no live VDI action — otherwise the Start button can't be reached
-        // for stopped VMs/CTs.
-        var showStopped = _chkStopped.IsChecked is true;
+        // A stopped VM only survived the list filter via HasAnyVdiAction, which for a
+        // stopped VM depends solely on its VGA being SPICE-capable (qxl/spice). A stopped
+        // VNC-only VM (e.g. vga: virtio) therefore vanished from the list while stopped
+        // SPICE VMs stayed visible, unless the "Stopped" status filter was ticked.
+        //
+        // Always include stopped-but-powerable rows so the Start button is reachable and
+        // behaviour is consistent across VGA types. Status filters still remove these when
+        // "Running" is selected.
         var list = filtered.Where(a => a.HasAnyVdiAction
-                                       || (showStopped && a.CanPower && !a.IsActive)).ToList();
+                                       || (a.CanPower && !a.IsActive)).ToList();
 
         // Sort VMs/CTs globally per the user's choice (nodes keep their alphabetical order
         // applied at fetch time). _allRows is built in two passes (LXC first, then QEMU),


### PR DESCRIPTION
## Problem

Fixes #37.

A stopped VM disappeared from the list unless it was SPICE-capable. Reported by @SampsonF: a Windows 11 VM (`vga: virtio`) vanished when powered off, while other stopped VMs stayed visible.

## Root cause

The list filter kept a row via `HasAnyVdiAction`:

```csharp
HasAnyVdiAction => Node || hasSpice || CanVnc
```

For a **stopped** VM:
- `CanVnc` requires `IsRunning` → `false`
- `hasSpice` comes from the VGA config → only `qxl`/`spice`

So a stopped VM survived **only** when its VGA was SPICE-capable. A stopped VNC-only VM (`vga: virtio`) had `HasAnyVdiAction == false` and was dropped. The fallback that would have kept it (`CanPower && !IsActive`) was gated behind the **"Stopped"** status filter being ticked, which the user did not have on.

## Fix

Drop the `showStopped` gate so stopped-but-powerable rows are always included. The Start button is now reachable for any powerable stopped VM regardless of VGA type. The status filters above still remove these rows when **"Running"** is selected.

## Testing

- `dotnet build` — 0 errors, 0 warnings.
